### PR TITLE
depend on dataclasses package only for python<3.7

### DIFF
--- a/more_properties/__init__.py
+++ b/more_properties/__init__.py
@@ -17,7 +17,7 @@ __all__ = [
     "cached_static_property",
 ]
 
-__version__ = "1.1.1"
+__version__ = "1.1.1.fbx.fix"
 
 # Providing aliases for consistency with classmethod and staticmethod
 classproperty = class_property

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-dataclasses
+dataclasses ; python_version < '3.7'


### PR DESCRIPTION
As of python3.7 dataclasses is built in to python
dataclasses package even changed their supported versions after 0.6 to `>=3.6, <3.7`
That means if we keep the dataclasses requirement we are stuck using dataclasses<=0.6 and don't use the built-in

Adding the suffix here will make sure we can use the built-in dataclasses